### PR TITLE
🔄 Game DB update from client

### DIFF
--- a/local-game-db.json
+++ b/local-game-db.json
@@ -247,7 +247,8 @@
       "f95Url": "https://f95zone.to/threads/90568/",
       "releaseDate": "2025-03-20",
       "knownTitles": [
-        "16 Years Later"
+        "16 Years Later",
+        "16_years_later"
       ],
       "status": "abandoned",
       "metaUpdatedAt": "2026-03-10T15:45:18.556Z",
@@ -1823,7 +1824,8 @@
       "releaseDate": "2025-11-18",
       "knownTitles": [
         "A Family Venture",
-        "AFamilyVenture-0.09_V3_supporter-pc"
+        "AFamilyVenture-0.09_V3_supporter-pc",
+        "AFamilyVenture-0.09_V2-Beta_supporter-pc"
       ],
       "status": "abandoned",
       "metaUpdatedAt": "2026-03-18T22:23:05.506Z",
@@ -13979,7 +13981,8 @@
       "f95Url": "https://f95zone.to/threads/28008/",
       "releaseDate": "2025-10-14",
       "knownTitles": [
-        "Bad Memories"
+        "Bad Memories",
+        "Bad_Memories"
       ],
       "status": "abandoned",
       "metaUpdatedAt": "2026-03-10T16:35:29.676Z",
@@ -14682,7 +14685,8 @@
       "releaseDate": null,
       "knownTitles": [
         "SVSReward-BeachVacation-1.0-pc",
-        "Beach Vacation"
+        "Beach Vacation",
+        "Beach_Vacation"
       ],
       "status": "completed",
       "metaUpdatedAt": "2026-03-10T16:38:03.501Z",
@@ -17181,7 +17185,8 @@
       "releaseDate": "2024-05-27",
       "knownTitles": [
         "Big Brother Renpy Remake Story",
-        "BigBrotherRenPy_RemakeStory-0.1-pc"
+        "BigBrotherRenPy_RemakeStory-0.1-pc",
+        "BigBrotherRenPy-0.13 (+7 fix) Final"
       ],
       "status": "abandoned",
       "lastVersionChecked": "1.07 - Fix 2 + Holidays - 0.01"
@@ -30333,7 +30338,8 @@
       "releaseDate": "Unknown Release Date",
       "knownTitles": [
         "CorruptedLove-0.9-pc",
-        "Corrupted Kingdoms V041"
+        "Corrupted Kingdoms V041",
+        "CorruptedLove-0.10a-pc_Rus"
       ],
       "status": "active",
       "metaUpdatedAt": "2026-08-01T22:04:15.991Z",
@@ -30582,7 +30588,8 @@
       "releaseDate": "2026-03-04",
       "knownTitles": [
         "Corruption",
-        "corruption-Final-1.0-pc"
+        "corruption-Final-1.0-pc",
+        "corruption-v0.15-pc"
       ],
       "status": "completed",
       "lastVersionChecked": "Final"
@@ -49252,7 +49259,8 @@
       "releaseDate": "2023-12-30",
       "knownTitles": [
         "FILF2-0.01b-pc",
-        "F.I.L.F. 2"
+        "F.I.L.F. 2",
+        "F.I.L.F"
       ],
       "status": "abandoned",
       "lastVersionChecked": "v0.01b"
@@ -56222,7 +56230,8 @@
       "releaseDate": "2024-03-14",
       "knownTitles": [
         "Freeloading Family",
-        "FreeloadingFamily-0.32-pc"
+        "FreeloadingFamily-0.32-pc",
+        "Freeloading_Family"
       ],
       "status": "completed",
       "lastVersionChecked": "v0.32"
@@ -63004,7 +63013,8 @@
       "releaseDate": "2021-08-08",
       "knownTitles": [
         "Haley-1.1-alt-pc",
-        "Haleys Story"
+        "Haleys Story",
+        "Haleys  Story"
       ],
       "status": "completed",
       "lastVersionChecked": "v1.1"
@@ -122509,7 +122519,8 @@
       "knownTitles": [
         "Princess_Trainer_2.03-win",
         "Princess_Trainer",
-        "Princess Trainer Gold Edition"
+        "Princess Trainer Gold Edition",
+        "Princess_Trainer_2.15-rus"
       ],
       "status": "completed",
       "lastVersionChecked": "V083"
@@ -138882,7 +138893,8 @@
       "knownTitles": [
         "Single Again",
         "SingleAgainCHP1-1.25-pc",
-        "Single Again Uimod"
+        "Single Again Uimod",
+        "Single Again CH1 Ru"
       ],
       "status": "abandoned",
       "metaUpdatedAt": "2026-07-20T22:34:48.028Z",
@@ -139634,7 +139646,8 @@
       "releaseDate": "2026-02-21",
       "knownTitles": [
         "SL-1.1.3-Uncensored Edition (PC)",
-        "Sisterly Lust"
+        "Sisterly Lust",
+        "Sisterly_Lust"
       ],
       "status": "completed",
       "metaUpdatedAt": "2026-03-10T18:21:43.333Z",
@@ -150657,7 +150670,8 @@
       "f95Url": "https://f95zone.to/threads/10384/",
       "releaseDate": "2026-05-31",
       "knownTitles": [
-        "Take Over"
+        "Take Over",
+        "Take_Over"
       ],
       "status": "active",
       "metaUpdatedAt": "2026-08-01T22:09:31.437Z",
@@ -151592,7 +151606,10 @@
         "Tamara Exposed",
         "TamaraExposed3-0.9.1-pc",
         "TamaraExposedTheBeginning-1.0-pc",
-        "TamaraExposedTheNextChapter-1.1-pc"
+        "TamaraExposedTheNextChapter-1.1-pc",
+        "TamaraExposed3-0.8-pc_Rus",
+        "TamaraExposedTheBeginning-1.0-pc-Rus",
+        "TamaraExposedTheNextChapter-1.1.002-pc-Rus"
       ],
       "metaUpdatedAt": "2026-08-01T22:23:20.289Z",
       "status": "active",
@@ -163493,7 +163510,8 @@
       "releaseDate": "2023-01-20",
       "knownTitles": [
         "The Princess And The Tower",
-        "ThePrincessAndTheTower-0.9b.1-pc"
+        "ThePrincessAndTheTower-0.9b.1-pc",
+        "ThePrincessAndTheTower_0.9c_PC"
       ],
       "status": "completed",
       "lastVersionChecked": "0.9c Public"
@@ -178885,7 +178903,8 @@
       "f95Url": "https://f95zone.to/threads/51349/",
       "releaseDate": "2025-02-26",
       "knownTitles": [
-        "What A Legend"
+        "What A Legend",
+        "What-a-Legend-0.4.01-pc"
       ],
       "status": "abandoned",
       "metaUpdatedAt": "2026-03-10T17:49:24.099Z",
@@ -181261,7 +181280,8 @@
       "f95Url": "https://f95zone.to/threads/1697/",
       "releaseDate": "2026-01-15",
       "knownTitles": [
-        "Witch Trainer Silver Mod"
+        "Witch Trainer Silver Mod",
+        "Witch_Trainer_Silver_Mod"
       ],
       "status": "abandoned",
       "metaUpdatedAt": "2026-05-15T22:45:08.003Z",


### PR DESCRIPTION
**Total games in DB:** 5846
**Updated:** 18

- 16_years_later (+aliases)
- AFamilyVenture-0.09_V2-Beta_supporter-pc (+aliases)
- Bad_Memories (+aliases)
- Beach_Vacation (+aliases)
- BigBrotherRenPy-0.13 (+7 fix) Final (+aliases)
- CorruptedLove-0.10a-pc_Rus (+aliases)
- corruption-v0.15-pc (+aliases)
- F.I.L.F (+aliases)
- Freeloading_Family (+aliases)
- Haleys  Story (+aliases)
- Princess_Trainer_2.15-rus (+aliases)
- Single Again CH1 Ru (+aliases)
- Sisterly_Lust (+aliases)
- Take_Over (+aliases)
- TamaraExposed3-0.8-pc_Rus (+aliases)
- ThePrincessAndTheTower_0.9c_PC (+aliases)
- What-a-Legend-0.4.01-pc (+aliases)
- Witch_Trainer_Silver_Mod (+aliases)

_Auto-submitted by RozpustaApp client_